### PR TITLE
Fix for both currently open issues. Fixes svg download!

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 
                     <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect" for="commercial">
                         <input type="checkbox" id="commercial" class="mdl-checkbox__input" checked>
-                        <span class="mdl-checkbox__label">License used does NOT restrict Non-Commercial use</span>
+                        <span class="mdl-checkbox__label">License used allows for commercial use</span>
                     </label>
 
                     <div style="margin-top: 10px">

--- a/main.js
+++ b/main.js
@@ -70,7 +70,7 @@ $('button').on('click', function () {
   var a = document.createElement('a');
   a.setAttribute('target', '_blank');
   a.setAttribute('download', 'oshw.svg');
-  a.setAttribute('href', 'data:image/svg+xml;utf8,' + unescape(svg[0].outerHTML));
+  a.setAttribute('href', 'data:image/svg+xml;utf8,' + unescape(svg[0].outerHTML).replaceAll("#", "%23"));
   $('body').append(a);
   a.click();
   $(a).remove();


### PR DESCRIPTION
This small edit fixes the save button functionality and changes the license options text as suggested in the issue.

Turns out the issue with the save button is that for some reason it doesnt like the # symbol in the href of the anchor. Simply doing a replaceAll and replacing them with %23 (url code for the # symbol) fixes this and when the browser saves the file it automatically converts it back. 

Just because I had forked it already I also changed the text for the license option as suggested...

Therefore this fixes both issues #5 and #4 


I know there havent been any commits since 9 years, but since I was trying to use the page today and came across this, thought Id fix it real quick and give you the fix anyways...